### PR TITLE
Tavo ajuste gestion pqrs

### DIFF
--- a/src/app/modules/admin/apps/pqr/gestion-pqrs/gestion-pqrs.component.html
+++ b/src/app/modules/admin/apps/pqr/gestion-pqrs/gestion-pqrs.component.html
@@ -70,10 +70,10 @@
                 </div>
                 <hr class="w-full border-t mt-2">
                 <div class="flex flex-col overflow-y-scroll h-40">
-                    <div class="flex flex-row justify-between mt-2">
+                    <div class="flex flex-row justify-between">
                         <div class="mb-1">Registros</div>
-                        <div>
-                            <a (click)="insertadjunti()" class="text-sm cursor-pointer" [hidden]="datos.estado!='Sin resolver'"><mat-icon matTooltip="Agregar adjuntos" svgIcon="heroicons_outline:document-add"></mat-icon></a>
+                        <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
+                            <a (click)="insertadjunti()" class="text-sm cursor-pointer"><mat-icon matTooltip="Agregar adjuntos" svgIcon="heroicons_outline:document-add"></mat-icon></a>
                         </div>
                     </div>
                     <div *ngFor="let item of listarAdjuntos" style="border-left: 5px solid #b6ce1d; padding-left: 3px;">
@@ -89,7 +89,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div>
+                            <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
                                 <a class="text-sm cursor-pointer"><mat-icon matTooltip="Eliminar adjunto" svgIcon="heroicons_outline:document-remove" (click)="eliminarAdjunto(item)"></mat-icon></a>
                             </div>
                         </div>
@@ -111,7 +111,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div>
+                            <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
                                 <a class="text-sm cursor-pointer"><mat-icon matTooltip="Eliminar adjunto" svgIcon="heroicons_outline:document-remove" (click)="eliminarAdjunto(item)"></mat-icon></a>
                             </div>
                         </div>

--- a/src/app/modules/admin/apps/pqr/gestion-pqrs/gestion-pqrs.component.html
+++ b/src/app/modules/admin/apps/pqr/gestion-pqrs/gestion-pqrs.component.html
@@ -72,7 +72,7 @@
                 <div class="flex flex-col overflow-y-scroll h-40">
                     <div class="flex flex-row justify-between">
                         <div class="mb-1">Registros</div>
-                        <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
+                        <div *ngIf="datos.estado=='Sin resolver'">
                             <a (click)="insertadjunti()" class="text-sm cursor-pointer"><mat-icon matTooltip="Agregar adjuntos" svgIcon="heroicons_outline:document-add"></mat-icon></a>
                         </div>
                     </div>
@@ -89,7 +89,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
+                            <div *ngIf="datos.estado=='Sin resolver'">
                                 <a class="text-sm cursor-pointer"><mat-icon matTooltip="Eliminar adjunto" svgIcon="heroicons_outline:document-remove" (click)="eliminarAdjunto(item)"></mat-icon></a>
                             </div>
                         </div>
@@ -111,7 +111,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div *ngIf="datos.estado=='Sin resolver' || datos.estado=='En espera'">
+                            <div *ngIf="datos.estado=='Sin resolver'">
                                 <a class="text-sm cursor-pointer"><mat-icon matTooltip="Eliminar adjunto" svgIcon="heroicons_outline:document-remove" (click)="eliminarAdjunto(item)"></mat-icon></a>
                             </div>
                         </div>


### PR DESCRIPTION
Los botones para añadir y eliminar documentos en gestión de pqrs ahora solo se ven si la pqrs esta en estado sin resolver.